### PR TITLE
Prevent trending articles from being erroneously included

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -47,7 +47,9 @@ def get_article_links(page: requests.models.Response) -> list:
     article_divs = soup.find_all("div", class_="PagePromo-title")
     article_links = []
     for article in article_divs:
-        article_links.append(article.a.get("href"))
+        # Prevents trending articles from accidentally being added
+        if len(article.a.get("class")) == 0:
+            article_links.append(article.a.get("href"))
     return article_links
 
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -48,7 +48,7 @@ def get_article_links(page: requests.models.Response) -> list:
     article_links = []
     for article in article_divs:
         # Prevents trending articles from accidentally being added
-        if len(article.a.get("class")) == 0:
+        if len(article.a.get("class")) == 1:
             article_links.append(article.a.get("href"))
     return article_links
 


### PR DESCRIPTION
Based on testing on my local machine, I'm almost certain this fixes the issue of articles that are trending being erroneously included in each news feed. Since I can't do a test deployment since I'm traveling abroad, I'm going to hold off on merging this for a bit.